### PR TITLE
fix YYSYNTH_DYNAMIC_PROPERTY_CTYPE 's _getter_ return type

### DIFF
--- a/YYKit/Base/YYKitMacro.h
+++ b/YYKit/Base/YYKitMacro.h
@@ -116,7 +116,7 @@ YY_EXTERN_C_BEGIN
     objc_setAssociatedObject(self, _cmd, value, OBJC_ASSOCIATION_RETAIN); \
     [self didChangeValueForKey:@#_getter_]; \
 } \
-- (type)_getter_ { \
+- (_type_)_getter_ { \
     _type_ cValue = { 0 }; \
     NSValue *value = objc_getAssociatedObject(self, @selector(_setter_:)); \
     [value getValue:&cValue]; \


### PR DESCRIPTION
YYKitMacro.h 中的 YYSYNTH_DYNAMIC_PROPERTY_CTYPE 的 _getter_ 的返回 type ，是 _type_ ，可能是你手误了。