### PR TITLE
YYCGUtilities: Fixed aspect fill rect calculation issue

### DIFF
--- a/YYKit/Base/Quartz/YYCGUtilities.m
+++ b/YYKit/Base/Quartz/YYCGUtilities.m
@@ -204,11 +204,18 @@ CGRect YYCGRectFitWithContentMode(CGRect rect, CGSize size, UIViewContentMode mo
                 rect.size = CGSizeZero;
             } else {
                 CGFloat scale;
-                if (size.width / size.height < rect.size.width / rect.size.height &&
-                    mode == UIViewContentModeScaleAspectFit) {
-                    scale = rect.size.height / size.height;
+                if (mode == UIViewContentModeScaleAspectFit) {
+                    if (size.width / size.height < rect.size.width / rect.size.height) {
+                        scale = rect.size.height / size.height;
+                    } else {
+                        scale = rect.size.width / size.width;
+                    }
                 } else {
-                    scale = rect.size.width / size.width;
+                    if (size.width / size.height < rect.size.width / rect.size.height) {
+                        scale = rect.size.width / size.width;
+                    } else {
+                        scale = rect.size.height / size.height;
+                    }
                 }
                 size.width *= scale;
                 size.height *= scale;


### PR DESCRIPTION
```objc
CGSize originSize = CGSizeMake(300, 50);
CGRect originRect = (CGRect){CGPointZero, originSize};
CGRect targetRect = CGRectMake(0, 0, 100, 100);

CGRect fitRect = YYCGRectFitWithContentMode(targetRect, originSize, UIViewContentModeScaleAspectFit);
CGRect fillRect = YYCGRectFitWithContentMode(targetRect, originSize, UIViewContentModeScaleAspectFill);

// Aspect
XCTAssert(CGRectGetWidth(fitRect) / CGRectGetHeight(fitRect) - CGRectGetWidth(originRect) / CGRectGetHeight(originRect) < FLT_EPSILON);
XCTAssert(CGRectGetWidth(fillRect) / CGRectGetHeight(fillRect) - CGRectGetWidth(originRect) / CGRectGetHeight(originRect) < FLT_EPSILON);

// AspectFit
XCTAssert(fabs(CGRectGetHeight(fitRect) - 50 / 3.0f) < 0.01f);
XCTAssert(fabs(CGRectGetWidth(fillRect) - 600) < FLT_EPSILON);
    
XCTAssertFalse(CGRectEqualToRect(fitRect, fillRect));
```

The origin method will not work under UIViewContentModeScaleAspectFill condition. You can re-produce the wrong result using the above test code. 