### PR TITLE
同NSTimer一样,此处的target的method签名应该是- (void)timerFireMethod:(YYTimer *)timer

### DIFF
--- a/YYKit/Utility/YYTimer.m
+++ b/YYKit/Utility/YYTimer.m
@@ -81,11 +81,11 @@ dispatch_semaphore_signal(_lock);
     selector = _selector;
     if (!_repeats || !_target) {
         dispatch_semaphore_signal(_lock);
-        [_target performSelector:_selector];
+        [_target performSelector:_selector withObject:self];
         [self invalidate];
     } else {
         dispatch_semaphore_signal(_lock);
-        [_target performSelector:_selector];
+        [_target performSelector:_selector withObject:self];
     }
 #pragma clang diagnostic pop
 }


### PR DESCRIPTION
The selector should have the following signature: timerFireMethod:
(including a colon to indicate that the method takes an argument). The
timer passes itself as the argument, thus the method would adopt the
following pattern