### PR TITLE
为 YYLabel 的 layer 增加 opaque 属性的支持

### DIFF
--- a/YYKit/Text/Component/YYTextLayout.h
+++ b/YYKit/Text/Component/YYTextLayout.h
@@ -275,7 +275,7 @@ extern const CGSize YYTextContainerMaxSize;
 @property (nonatomic, readonly) BOOL needDrawBorder;
 
 ///< Draw background with color when YYLabel.layer.opaque equal to YES
-@property (nullable, nonatomic, readonly) UIColor* opaqueBackgroundColor;
+@property (nullable, nonatomic) UIColor* opaqueBackgroundColor;
 
 #pragma mark - Query information from text layout
 ///=============================================================================

--- a/YYKit/Text/Component/YYTextLayout.h
+++ b/YYKit/Text/Component/YYTextLayout.h
@@ -274,6 +274,8 @@ extern const CGSize YYTextContainerMaxSize;
 ///< Has border attribute
 @property (nonatomic, readonly) BOOL needDrawBorder;
 
+///< Draw background with color when YYLabel.layer.opaque equal to YES
+@property (nullable, nonatomic, readonly) UIColor* opaqueBackgroundColor;
 
 #pragma mark - Query information from text layout
 ///=============================================================================

--- a/YYKit/Text/Component/YYTextLayout.m
+++ b/YYKit/Text/Component/YYTextLayout.m
@@ -3282,6 +3282,14 @@ static void YYTextDrawDebug(YYTextLayout *layout, CGContextRef context, CGSize s
 }
 
 
+static void YYTextBackgroundColor(UIColor *color, CGContextRef context, CGSize size, CGPoint point, BOOL (^cancel)(void)) {
+    CGContextSaveGState(context); {
+        CGContextSetFillColorWithColor(context, color.CGColor);
+        CGContextFillRect(context, CGRectMake(point.x, point.y, size.width, size.height));
+    } CGContextRestoreGState(context);
+}
+
+
 - (void)drawInContext:(CGContextRef)context
                  size:(CGSize)size
                 point:(CGPoint)point
@@ -3290,6 +3298,10 @@ static void YYTextDrawDebug(YYTextLayout *layout, CGContextRef context, CGSize s
                 debug:(YYTextDebugOption *)debug
                 cancel:(BOOL (^)(void))cancel{
     @autoreleasepool {
+        if (self.opaqueBackgroundColor && context) {
+            if (cancel && cancel()) return;
+            YYTextBackgroundColor(self.opaqueBackgroundColor, context, size, point, cancel);
+        }
         if (self.needDrawBlockBorder && context) {
             if (cancel && cancel()) return;
             YYTextDrawBlockBorder(self, context, size, point, cancel);

--- a/YYKit/Text/Component/YYTextLayout.m
+++ b/YYKit/Text/Component/YYTextLayout.m
@@ -3300,7 +3300,7 @@ static void YYTextBackgroundColor(UIColor *color, CGContextRef context, CGSize s
     @autoreleasepool {
         if (self.opaqueBackgroundColor && context) {
             if (cancel && cancel()) return;
-            YYTextBackgroundColor(self.opaqueBackgroundColor, context, size, point, cancel);
+             YYTextBackgroundColor(self.opaqueBackgroundColor, context, self.container.size, CGPointZero, cancel);
         }
         if (self.needDrawBlockBorder && context) {
             if (cancel && cancel()) return;


### PR DESCRIPTION
当`layer.opaque = YES`时候，当前版本的`YYLabel`背景颜色为黑色。
在`YYTextLayout`增加`opaqueBackgroundColor`属性，当不为nil的时候，绘制背景颜色。

应用场景：
当`YYLabel`只用做展示,不需要接受触摸事件的时候，添加其`layer`作为展示，减少`view`的层级。