### PR TITLE
add HitTest

### DIFF
--- a/YYKit/Text/YYLabel.m
+++ b/YYKit/Text/YYLabel.m
@@ -640,6 +640,21 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     if (!_state.swallowTouch) [super touchesCancelled:touches withEvent:event];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
+    UIView *hitResult = [super hitTest:point withEvent:event];
+    
+    if (hitResult != self) {
+        return hitResult;
+    }
+    
+    YYTextHighlight *highlight = [self _getHighlightAtPoint:point range:NULL];
+    if (!highlight) {
+        return nil;
+    }
+    
+    return hitResult;
+}
+
 #pragma mark - Properties
 
 - (void)setText:(NSString *)text {


### PR DESCRIPTION
Add hitTest. Now, when user tap somewhere that has no highlights, the
views behind can perform

解决无法触发Label后面view的事件的问题，请检阅。
