### PR TITLE
fix bug: YYTextEffectWindow 成为 KeyWindow后，长按YYTextView 不能弹出菜单的问题

### DIFF
--- a/YYKit/Text/Component/YYTextEffectWindow.m
+++ b/YYKit/Text/Component/YYTextEffectWindow.m
@@ -49,6 +49,12 @@
     return one;
 }
 
+// stop self from becoming the KeyWindow
+- (void)becomeKeyWindow
+{
+    [[[UIApplication sharedExtensionApplication].delegate window] makeKeyWindow];
+}
+
 - (UIViewController *)rootViewController {
     for (UIWindow *window in [[UIApplication sharedExtensionApplication] windows]) {
         if (self == window) continue;


### PR DESCRIPTION
#113 这个问题的解决方案