### PR TITLE
解决yylable在autolayout下自适应时设置对齐方式之后文本intrinsicContentSize计算错误的数值返回导致文本看…

### DIFF
--- a/YYKit/Text/YYLabel.m
+++ b/YYKit/Text/YYLabel.m
@@ -1031,7 +1031,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
         container.size = YYTextContainerMaxSize;
         
         YYTextLayout *layout = [YYTextLayout layoutWithContainer:container text:_innerText];
-        return layout.textBoundingSize;
+        return layout.textBoundingRect.size;
     }
     
     CGSize containerSize = _innerContainer.size;
@@ -1049,7 +1049,7 @@ static dispatch_queue_t YYLabelGetReleaseQueue() {
     container.size = containerSize;
     
     YYTextLayout *layout = [YYTextLayout layoutWithContainer:container text:_innerText];
-    return layout.textBoundingSize;
+    return layout.textBoundingRect.size;
 }
 
 #pragma mark - YYTextDebugTarget


### PR DESCRIPTION
…不到。 用reveal查看会Lable超级长.

NSMutableAttributedString *arrt= [[NSMutableAttributedString  alloc] initWithString:@"asdasdddddddddddddddddd"];
    arrt.color = [UIColor redColor];
    arrt.alignment = NSTextAlignmentRight;
    YYTextLayout *textlayout = [YYTextLayout layoutWithContainerSize:CGSizeMake(CGFLOAT_MAX, CGFLOAT_MAX) text:arrt];
上面代码在修复前会超级长。在修复后变正常。布局起来就想uilable一样简单