### PR TITLE
add property copy and customize encoding/decoding methods

### DIFF
--- a/Demo/YYKitDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Demo/YYKitDemo.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/YYKit/Model/NSObject+YYModel.h
+++ b/YYKit/Model/NSObject+YYModel.h
@@ -177,6 +177,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable id)modelCopy;
 
 /**
+ SHADOW copy properties from sourceObj to self
+ Roen(https://github.com/Roen-Ro) added/2018.12.24
+ 
+ @param sourceObj the copy source, type safe
+ */
+-(void)copyPropertiesFromSourceObject:(id)sourceObj;
+
+/**
  Encode the receiver's properties to a coder.
  
  @param aCoder  An archiver object.
@@ -435,6 +443,17 @@ NS_ASSUME_NONNULL_BEGIN
  @return Returns YES if the model is valid, or NO to ignore this model.
  */
 - (BOOL)modelCustomTransformToDictionary:(NSMutableDictionary *)dic;
+
+/**
+ Do customer encode/decode, for subclass to override
+ Roen(https://github.com/Roen-Ro) added/2018.12.24
+ 
+ @param propertyKey the property key
+ @param aCoder /aDecoder the decoder/encoder
+ @return return YES for the properties if you wish to do customer encoding/decoding, else return NO, default return NO
+ */
+-(BOOL)shouldCustomEncodeValueForKey:(NSString *)propertyKey withCoder:(NSCoder *)aCoder;
+-(BOOL)shouldCustomDecodeValueForKey:(NSString *)propertyKey withCoder:(NSCoder *)aDecoder;
 
 @end
 


### PR DESCRIPTION
1. 给YYModel添加了自定义 encode/decode方法
```objc
-(BOOL)shouldCustomEncodeValueForKey:(NSString *)propertyKey withCoder:(NSCoder *)aCoder;
-(BOOL)shouldCustomDecodeValueForKey:(NSString *)propertyKey withCoder:(NSCoder *)aDecoder;
```
程序员可以在子类重写这两个方法来自定义一些属性的encode/decode，比如一些struct结构体，或者做一些历史版本数据的兼容，就很必要用到这两个方法。

2. 给YYModel添加了从其他对象拷贝属性的方法
添加的方法：
```objc
-(void)copyPropertiesFromSourceObject:(id)sourceObj
```
通过这个方法将一个对象A的属性全部拷贝到已有的对象B上，而不需要新建创建对象
